### PR TITLE
add spanish translation

### DIFF
--- a/fastlane/metadata/android/es-ES/full_description.txt
+++ b/fastlane/metadata/android/es-ES/full_description.txt
@@ -1,0 +1,39 @@
+¡La aplicación Evil Insult Generator es el generador de insultos más genial que existe!
+¡Esta es la mejor aplicación de insultos que puedes obtener! Lo mejor de todo es que es de uso gratuito.
+¿Estás buscando una aplicación de insultos malvados? ¿Quieres divertirte un poco con los mensajes que envías a tus amigos? Tal vez estés buscando un insulto divertido que pueda hacer que tu novia o novio actual rompa contigo. Si te falta creatividad y necesitas ayuda, ¡esta aplicación es para ti! La aplicación Evil Insult Generator se puede descargar e instalar de forma gratuita. No solo disfrutarás de los insultos que genera, ¡también podrás compartirlos!
+Esta aplicación es capaz de generar miles de combinaciones de insultos, y cada una se siente diferente. Estos insultos malvados se pueden compartir con amigos si quieres hacerlos reír. Los fanáticos del juego "Cards Against Humanity" apreciarán este increíble generador de insultos, ¡que es totalmente gratuito!
+Disfrutarás insultando a enemigos y amigos por igual. Eso sí, la aplicación de insultos se creó para divertirse, no debe usarse para hacer que nadie se sienta mal intencionalmente.
+La aplicación de insultos es una de las mejores de su tipo. Realmente te puede dar una mano si no puedes pensar en un insulto lo suficientemente bueno por tu cuenta.
+¿Interesado en difamar a alguien? ¡Esta aplicación se sumergirá en su colección de burlas insultantes e impactantes! A veces, es difícil encontrar ciertas palabras en el momento. Cuando eso sucede, esta aplicación da un paso al frente!
+¿Necesitas encontrar un término ofensivo para llamar a alguien? Puede acceder a cientos de insultos para usar. Nuevos insultos están a un toque de distancia. Simplemente presione el botón marcado "Generar" y aparecerá un insulto completamente nuevo en el medio de su pantalla.
+Podrás crear divertidos insultos con solo presionar un botón. Los insultos que uses serán originales.
+Gracias a esta aplicación de insultos, podrá desahogarse cuando quieras. Puedes escupir insultos en griego, hindi, ruso, swahili, español, alemán, francés, chino y, por supuesto, inglés.
+La aplicación simplifica el proceso de inventar un insulto, y también puedes compartir tus insultos en otras aplicaciones. No dejes que esta oportunidad se te escape: descarga este generador de insultos para tu(s) dispositivo(s). ¿Estás tratando de encontrar una gran frase para usar con alguien? Esta variedad de insultos transmitirá tu mensaje de forma humorística. ¡Serás escuchado alto y claro!
+
+¿Por qué debería descargar Evil Insult Generator,en lugar de otra aplicación de insultos?
+
+<b>Simplicidad</b>
+La interfaz es amigable y los gráficos son de alta calidad. La aplicación fue desarrollada para brindar una experiencia placentera.
+En la pantalla principal de la aplicación, tendrás la capacidad de generar y explorar varios insultos malvados. Usar la aplicación no podría ser más fácil y solo toma un segundo generar nuevos insultos. Puede navegar a través de ellos con un simple toque en su pantalla
+
+<b> Gratis </b>
+Esta aplicación es de uso completamente gratuito y permanecerá así para siempre. El código fuente está disponible en GitHub. No tiene que preocuparse por membresías especiales, suscripciones anuales o costos ocultos para generar resultados y compartirlos con otros.
+
+<b> Compartir </b>
+Nos esforzamos por simplificar el proceso de uso de esta aplicación. Podrás compartir los insultos producidos por el Evil Insult Generator sin cargo. Sus insultos se pueden compartir con amigos en varias aplicaciones.
+
+<b> Actualizado Periódicamente </b>
+El equipo de desarrollo que creó esta aplicación siempre le está agregando nuevos insultos. Cada insulto es fácil de compartir y otros pueden usarlos si lo desean.
+Pero necesitamos tu apoyo. Envíanos tus insultos y lo revisaremos. Si nos gusta, el insulto será la incorporación más reciente a la aplicación.
+
+<b> Una enorme colección de insultos </b>
+Esta aplicación no escasea de insultos que puedas usar. Muchos de ellos tienen una singularidad que no se puede encontrar en ningún otro lugar.
+No se demore: descargue la aplicación Evil Insult Generator y cree frases creativas que pueda usar con casi cualquier persona.
+Nos esforzamos por optimizar las experiencias de los usuarios para todos. El feedback es algo que agradecemos. Si tiene alguna recomendación o sugerencia, nos gustaría escucharla. No dude en ponerse en contacto con nosotros en marvin@evilinsult.com. Al hacerlo, podremos optimizar su experiencia y mantener la aplicación actualizada con insultos de vanguardia.
+
+Nota: este generador de insultos utiliza software de código abierto. La fuente se puede encontrar aquí: https://github.com/EvilInsultGenerator/.
+Se agradece mucho su ayuda con la traducción de la aplicación: https://www.transifex.com/evil-insult-generator/.
+
+<b> ⚠️ Advertencia ⚠️ </b>
+Muchos insultos que genera la aplicación ofenderán a algunas personas y, como tal, debes tener cuidado con quién usas estos insultos. Esta aplicación es solo para usuarios maduros.
+

--- a/fastlane/metadata/android/es-ES/short_description.txt
+++ b/fastlane/metadata/android/es-ES/short_description.txt
@@ -1,0 +1,1 @@
+¡Esta es la mejor aplicación de insultos que puedes conseguir!


### PR DESCRIPTION
added spanish translation in fastlane/metadata/android/es-ES/ and I wanted to tell you that there is a typo on fastlane/metadata/android/en-US/ on the short description file name, I didn't change it to avoid  conflicts with the  branch

