### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,8 +24,8 @@
     <style name="AppTheme.OutlinedButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
         <item name="backgroundTint">@color/outlined_btn_bg_color</item>
         <item name="rippleColor">@color/outlined_btn_ripple_color</item>
-        <item name="strokeColor">@color/outlined_btn_stroke_color</item>
-        <item name="android:textColor">@color/outlined_btn_stroke_color</item>
+        <item name="strokeColor">#B05C22</item>
+        <item name="android:textColor">#B05C22</item>
         <item name="android:minHeight">48dp</item>
     </style>
 


### PR DESCRIPTION
The original text color of the component is '#EE7C2F', and the contrast between the text color ('#EE7C2F') and the background color ('#FAFAFA') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#B05C22') are as follows:
![image](https://user-images.githubusercontent.com/101503193/184933273-671fc728-7392-408a-b650-c1337e476318.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.